### PR TITLE
Rearranged layouts for pit scouting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         <activity
             android:name=".PitScoutingActivity"
             android:label="@string/title_activity_pit_scouting"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar"
+            android:windowSoftInputMode="adjustPan"></activity>
 <!--        <activity
             android:name=".WordCloudFragment"
             android:label=".WordCloudActivity"

--- a/app/src/main/java/com/frcteam195/cyberscouter/AutoTab.java
+++ b/app/src/main/java/com/frcteam195/cyberscouter/AutoTab.java
@@ -66,7 +66,7 @@ public class AutoTab extends Fragment implements IOnEditTextSaveListener {
             humanPlayer.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                    updateSpinnerValue(CyberScouterContract.Teams.COLUMN_NAME_AUTO_START_POS_ID, i);
+                    updateSpinnerValue(CyberScouterContract.Teams.COLUMN_NAME_AUTO_HUMAN, i);
                 }
 
                 @Override
@@ -239,7 +239,8 @@ public class AutoTab extends Fragment implements IOnEditTextSaveListener {
 
             Spinner sp = _view.findViewById(R.id.spinner_StartPosition);
             sp.setSelection(cst.getAutoStartPosID());
-
+            sp = _view.findViewById((R.id.spinner_HumanPlayer));
+            sp.setSelection(cst.getAutoHuman());
         }
     }
 

--- a/app/src/main/java/com/frcteam195/cyberscouter/EndgameTab.java
+++ b/app/src/main/java/com/frcteam195/cyberscouter/EndgameTab.java
@@ -48,7 +48,7 @@ public class EndgameTab extends Fragment implements IOnEditTextSaveListener {
             }
         });
 
-        Spinner spinnerPositionOnBar = view.findViewById(R.id.spinnerPositionOnBar);
+        /*Spinner spinnerPositionOnBar = view.findViewById(R.id.spinnerPositionOnBar);
         ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(),
                 android.R.layout.simple_spinner_dropdown_item, positionOnBar);
         spinnerPositionOnBar.setAdapter(adapter);
@@ -62,7 +62,7 @@ public class EndgameTab extends Fragment implements IOnEditTextSaveListener {
             public void onNothingSelected(AdapterView<?> adapterView) {
 
             }
-        });
+        });*/
 
         Spinner spinnerTypicalHighestRung = view.findViewById(R.id.spinnerTypicalHighestRung);
         ArrayAdapter<String> adapter1 = new ArrayAdapter<>(getActivity(),

--- a/app/src/main/java/com/frcteam195/cyberscouter/PhysicalPropertiesTab.java
+++ b/app/src/main/java/com/frcteam195/cyberscouter/PhysicalPropertiesTab.java
@@ -25,6 +25,7 @@ public class PhysicalPropertiesTab extends Fragment implements IOnEditTextSaveLi
     private Button button;
     private final int[] gearSpeedButtons = {R.id.gearSpeed1, R.id.gearSpeed2, R.id.gearSpeed3};
     private final int[] pneumaticsYNButtons = {R.id.pneumaticsNo, R.id.pneumaticsYes};
+    private final int[] carryCapacityButtons = {R.id.carryingCapacity1, R.id.carryingCapacity2, R.id.carryingCapacity3};
     private View _view;
     private int defaultButtonBackgroundColor = Color.LTGRAY;
     private final int SELECTED_BUTTON_TEXT_COLOR = Color.GREEN;
@@ -32,6 +33,7 @@ public class PhysicalPropertiesTab extends Fragment implements IOnEditTextSaveLi
     private int numberOfWheels = 0;
     private int pneumatics = -1;
     private int gearSpeed = -1;
+    private int carryingCapacity = -1;
     private String[] driveTypes = {"Swerve", "Mecanum", "Tank", "H-Drive", "Other"};
     private String[] motorTypes = {"CIM", "NEO", "Falcon", "Other"};
     private String[] wheelTypes = {"Colson", "Mecanum", "Tread", "Omni", "Pneumatic", "Traction", "Other"};
@@ -201,6 +203,30 @@ public class PhysicalPropertiesTab extends Fragment implements IOnEditTextSaveLi
             }
         });
 
+        button = view.findViewById(R.id.carryingCapacity1);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                carryingCapacityZero();
+            }
+        });
+
+        button = view.findViewById(R.id.carryingCapacity2);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                carryingCapacityOne();
+            }
+        });
+
+        button = view.findViewById(R.id.carryingCapacity3);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                carryingCapacityTwo();
+            }
+        });
+
         return view;
     }
 
@@ -279,6 +305,8 @@ public class PhysicalPropertiesTab extends Fragment implements IOnEditTextSaveLi
             FakeRadioGroup.buttonDisplay(getActivity(), _view, pneumatics, pneumaticsYNButtons, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
             gearSpeed = cst.getNumGearSpeed();
             FakeRadioGroup.buttonDisplay(getActivity(), _view, gearSpeed, gearSpeedButtons, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
+            carryingCapacity = cst.getMaxBallCapacity();
+            FakeRadioGroup.buttonDisplay(getActivity(), _view, carryingCapacity, carryCapacityButtons, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
 
             Spinner sp = _view.findViewById(R.id.driveTypePicker);
             sp.setSelection(cst.getDriveTypeID());
@@ -368,6 +396,39 @@ public class PhysicalPropertiesTab extends Fragment implements IOnEditTextSaveLi
         pneumatics = 0;
         try {
             CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_PNEUMATICS, 0, currentTeam);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void carryingCapacityZero() {
+        FakeRadioGroup.buttonPressed(getActivity(), _view, 0, carryCapacityButtons,
+                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
+                defaultButtonBackgroundColor);
+        try {
+            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 0, currentTeam);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void carryingCapacityOne() {
+        FakeRadioGroup.buttonPressed(getActivity(), _view, 1, carryCapacityButtons,
+                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
+                defaultButtonBackgroundColor);
+        try {
+            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 1, currentTeam);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void carryingCapacityTwo() {
+        FakeRadioGroup.buttonPressed(getActivity(), _view, 2, carryCapacityButtons,
+                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
+                defaultButtonBackgroundColor);
+        try {
+            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 2, currentTeam);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/com/frcteam195/cyberscouter/TeleopTab.java
+++ b/app/src/main/java/com/frcteam195/cyberscouter/TeleopTab.java
@@ -22,7 +22,6 @@ public class TeleopTab extends Fragment implements IOnEditTextSaveListener {
     private final int[] defenseYN = {R.id.button_playDefenseNo, R.id.button_playDefenseYes};
     private final int[] evadeYN = {R.id.button_evadeDefenseNo, R.id.button_evadeDefenseYes};
     private final int[] shootWhileDriveYN = {R.id.button_shootWhileDrivingNo, R.id.button_shootWhileDrivingYes};
-    private final int[] carryCapacityButtons = {R.id.button_carryingCapacityZero, R.id.button_carryingCapacityOne, R.id.button_carryingCapacityTwo};
     private int defaultButtonBackgroundColor = Color.LTGRAY;
     private final int SELECTED_BUTTON_TEXT_COLOR = Color.GREEN;
 
@@ -35,42 +34,6 @@ public class TeleopTab extends Fragment implements IOnEditTextSaveListener {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_teleop, container, false);
         _view = view;
-
-        Button button = view.findViewById(R.id.button_cargoScoredHighTelePlus);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                scoredHighTelePlus();
-            }
-        });
-
-        button = view.findViewById(R.id.button_cargoScoredHighTeleMinus);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                scoredHighTeleMinus();
-            }
-        });
-
-        button = view.findViewById(R.id.button_cargoScoredLowTelePlus);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                scoredLowTelePlus();
-            }
-        });
-
-        button = view.findViewById(R.id.button_cargoScoredLowTeleMinus);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                scoredLowTeleMinus();
-            }
-        });
 
         button = view.findViewById(R.id.button_sortCargoNo);
         button.setOnClickListener(new View.OnClickListener() {
@@ -144,33 +107,6 @@ public class TeleopTab extends Fragment implements IOnEditTextSaveListener {
             }
         });
 
-        button = view.findViewById(R.id.button_carryingCapacityZero);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                carryingCapacityZero();
-            }
-        });
-
-        button = view.findViewById(R.id.button_carryingCapacityOne);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                carryingCapacityOne();
-            }
-        });
-
-        button = view.findViewById(R.id.button_carryingCapacityTwo);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-
-            public void onClick(View view) {
-                carryingCapacityTwo();
-            }
-        });
-
         return (view);
     }
 
@@ -211,65 +147,14 @@ public class TeleopTab extends Fragment implements IOnEditTextSaveListener {
             EditText et = _view.findViewById(R.id.editText_teleopStrat);
             et.setText(String.valueOf(cst.getTeleStrategy()));
             et.setSelectAllOnFocus(true);
-
-            button = _view.findViewById(R.id.textButton_cargoScoredHighTeleCounter);
-            button.setText(String.valueOf(cst.getTeleBallsScoredHigh()));
-            scoredHighTele = cst.getTeleBallsScoredHigh();
-            button = _view.findViewById(R.id.textButton_scoredLowTeleCounter);
-            button.setText(String.valueOf(cst.getTeleBallsScoredLow()));
-            scoredLowTele = cst.getTeleBallsScoredLow();
+            et = _view.findViewById(R.id.editText_defenseStrat);
+            et.setText(String.valueOf(cst.getTeleDefenseStrat()));
+            et.setSelectAllOnFocus(true);
 
             FakeRadioGroup.buttonDisplay(getActivity(), _view, cst.getTeleSortCargo(), sortCargoYN, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
             FakeRadioGroup.buttonDisplay(getActivity(), _view, cst.getTeleDefense(), defenseYN, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
             FakeRadioGroup.buttonDisplay(getActivity(), _view, cst.getTeleDefenseEvade(), evadeYN, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
             FakeRadioGroup.buttonDisplay(getActivity(), _view, cst.getTeleShootWhileDrive(), shootWhileDriveYN, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
-            FakeRadioGroup.buttonDisplay(getActivity(), _view, cst.getMaxBallCapacity(), carryCapacityButtons, SELECTED_BUTTON_TEXT_COLOR, defaultButtonBackgroundColor);
-        }
-    }
-
-    private void scoredHighTelePlus() {
-        button = _view.findViewById(R.id.textButton_cargoScoredHighTeleCounter);
-        scoredHighTele++;
-        button.setText(String.valueOf(scoredHighTele));
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_TELE_BALLS_SCORED_HIGH, scoredHighTele, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void scoredHighTeleMinus() {
-        button = _view.findViewById(R.id.textButton_cargoScoredHighTeleCounter);
-        if (scoredHighTele > 0)
-            scoredHighTele--;
-        button.setText(String.valueOf(scoredHighTele));
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_TELE_BALLS_SCORED_HIGH, scoredHighTele, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void scoredLowTelePlus() {
-        button = _view.findViewById(R.id.textButton_scoredLowTeleCounter);
-        scoredLowTele++;
-        button.setText(String.valueOf(scoredLowTele));
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_TELE_BALLS_SCORED_LOW, scoredLowTele, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void scoredLowTeleMinus() {
-        button = _view.findViewById(R.id.textButton_scoredLowTeleCounter);
-        if (scoredLowTele > 0)
-            scoredLowTele--;
-        button.setText(String.valueOf(scoredLowTele));
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_TELE_BALLS_SCORED_LOW, scoredLowTele, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 
@@ -356,39 +241,6 @@ public class TeleopTab extends Fragment implements IOnEditTextSaveListener {
                 defaultButtonBackgroundColor);
         try {
             CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_TELE_SHOOT_WHILE_DRIVE, 1, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void carryingCapacityZero() {
-        FakeRadioGroup.buttonPressed(getActivity(), _view, 0, carryCapacityButtons,
-                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
-                defaultButtonBackgroundColor);
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 0, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void carryingCapacityOne() {
-        FakeRadioGroup.buttonPressed(getActivity(), _view, 1, carryCapacityButtons,
-                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
-                defaultButtonBackgroundColor);
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 1, currentTeam);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void carryingCapacityTwo() {
-        FakeRadioGroup.buttonPressed(getActivity(), _view, 2, carryCapacityButtons,
-                CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, SELECTED_BUTTON_TEXT_COLOR,
-                defaultButtonBackgroundColor);
-        try {
-            CyberScouterTeams.updateTeamMetric(_db, CyberScouterContract.Teams.COLUMN_NAME_MAX_BALL_CAPACITY, 2, currentTeam);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/src/main/res/layout/fragment_auto.xml
+++ b/app/src/main/res/layout/fragment_auto.xml
@@ -281,7 +281,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="56dp"
         android:text="@string/StartPositionPit"
-        android:textSize="31sp"
+        android:textSize="27sp"
         app:layout_constraintStart_toStartOf="@+id/button_WorkingAutoYes"
         app:layout_constraintTop_toBottomOf="@+id/button_WorkingAutoYes" />
 

--- a/app/src/main/res/layout/fragment_endgame.xml
+++ b/app/src/main/res/layout/fragment_endgame.xml
@@ -7,14 +7,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.main.PlaceholderFragment">
 
-    <Spinner
-        android:id="@+id/spinnerPositionOnBar"
-        android:layout_width="300dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="28dp"
-        app:layout_constraintStart_toStartOf="@+id/textView4"
-        app:layout_constraintTop_toBottomOf="@+id/textView4" />
-
     <TextView
         android:id="@+id/canTheyClimb"
         android:layout_width="wrap_content"
@@ -56,17 +48,6 @@
         android:text="@string/typicalHighestRung"
         android:textAlignment="center"
         android:textSize="45sp"
-        app:layout_constraintStart_toStartOf="@+id/textView4"
-        app:layout_constraintTop_toBottomOf="@+id/spinnerPositionOnBar" />
-
-    <TextView
-        android:id="@+id/textView4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="36dp"
-        android:text="@string/positionOnBar"
-        android:textAlignment="center"
-        android:textSize="45sp"
         app:layout_constraintStart_toStartOf="@+id/canTheyClimb"
         app:layout_constraintTop_toBottomOf="@+id/yesCanTheyClimb" />
 
@@ -89,7 +70,7 @@
         android:textAlignment="center"
         android:textSize="45sp"
         app:layout_constraintStart_toStartOf="@+id/centerClimb"
-        app:layout_constraintTop_toTopOf="@+id/textView4" />
+        app:layout_constraintTop_toTopOf="@+id/moveOnBar" />
 
     <EditText
         android:id="@+id/editText_endgameStrat"

--- a/app/src/main/res/layout/fragment_physical_properties.xml
+++ b/app/src/main/res/layout/fragment_physical_properties.xml
@@ -8,6 +8,45 @@
     tools:context=".ui.main.PlaceholderFragment">
 
     <TextView
+        android:id="@+id/text_CarryingCapacity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/CarryingCapacity"
+        android:textSize="30sp"
+        app:layout_constraintStart_toStartOf="@+id/motorMinusButton"
+        app:layout_constraintTop_toBottomOf="@+id/motorMinusButton" />
+
+    <Button
+        android:id="@+id/carryingCapacity1"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="12dp"
+        android:text="@string/one"
+        android:textSize="15sp"
+        app:layout_constraintStart_toStartOf="@+id/text_CarryingCapacity"
+        app:layout_constraintTop_toBottomOf="@+id/text_CarryingCapacity" />
+
+    <Button
+        android:id="@+id/carryingCapacity3"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:text="@string/three"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="@+id/text_CarryingCapacity"
+        app:layout_constraintTop_toTopOf="@+id/carryingCapacity2" />
+
+    <Button
+        android:id="@+id/carryingCapacity2"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:text="@string/two"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toStartOf="@+id/carryingCapacity3"
+        app:layout_constraintStart_toEndOf="@+id/carryingCapacity1"
+        app:layout_constraintTop_toTopOf="@+id/carryingCapacity1" />
+
+    <TextView
         android:id="@+id/size"
         android:layout_width="250dp"
         android:layout_height="50dp"

--- a/app/src/main/res/layout/fragment_teleop.xml
+++ b/app/src/main/res/layout/fragment_teleop.xml
@@ -18,12 +18,13 @@
         android:id="@+id/textview_sortCargo"
         android:layout_width="208dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="120dp"
+        android:layout_marginStart="300dp"
+        android:layout_marginTop="32dp"
         android:text="@string/SortCargo"
         android:textAlignment="center"
         android:textSize="30sp"
-        app:layout_constraintStart_toEndOf="@+id/textview_AverageScoredTeleop"
-        app:layout_constraintTop_toTopOf="@+id/textview_AverageScoredTeleop" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/textview_teleopStrategy"
@@ -46,119 +47,6 @@
         android:textSize="30sp"
         app:layout_constraintStart_toStartOf="@+id/textview_playDefense"
         app:layout_constraintTop_toBottomOf="@+id/button_playDefenseYes" />
-
-    <Button
-        android:id="@+id/textButton_scoredLowTeleCounter"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:background="@android:color/transparent"
-        android:text="0"
-        android:textAlignment="center"
-        android:textSize="40sp"
-        app:layout_constraintEnd_toStartOf="@+id/button_cargoScoredLowTelePlus"
-        app:layout_constraintStart_toEndOf="@+id/button_cargoScoredLowTeleMinus"
-        app:layout_constraintTop_toTopOf="@+id/button_cargoScoredLowTeleMinus" />
-
-    <Button
-        android:id="@+id/button_cargoScoredLowTelePlus"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:text="@string/PlusButton"
-        android:textSize="30sp"
-        app:layout_constraintEnd_toEndOf="@+id/textview_LowHubTele"
-        app:layout_constraintTop_toTopOf="@+id/button_cargoScoredLowTeleMinus" />
-
-    <Button
-        android:id="@+id/button_cargoScoredLowTeleMinus"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/MinusButton"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/textview_LowHubTele"
-        app:layout_constraintTop_toBottomOf="@+id/textview_LowHubTele" />
-
-    <Button
-        android:id="@+id/button_carryingCapacityZero"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/ZeroText"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/textview_CarryingCapacity"
-        app:layout_constraintTop_toBottomOf="@+id/textview_CarryingCapacity" />
-
-    <Button
-        android:id="@+id/button_carryingCapacityTwo"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:text="@string/two"
-        android:textSize="30sp"
-        app:layout_constraintEnd_toEndOf="@+id/textview_CarryingCapacity"
-        app:layout_constraintTop_toTopOf="@+id/button_carryingCapacityZero" />
-
-    <Button
-        android:id="@+id/button_carryingCapacityOne"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:text="@string/one"
-        android:textSize="30sp"
-        app:layout_constraintEnd_toStartOf="@+id/button_carryingCapacityTwo"
-        app:layout_constraintStart_toEndOf="@+id/button_carryingCapacityZero"
-        app:layout_constraintTop_toTopOf="@+id/button_carryingCapacityZero" />
-
-    <Button
-        android:id="@+id/button_cargoScoredHighTeleMinus"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/MinusButton"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/textview_HighHubTele"
-        app:layout_constraintTop_toBottomOf="@+id/textview_HighHubTele" />
-
-    <Button
-        android:id="@+id/button_cargoScoredHighTelePlus"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:text="@string/PlusButton"
-        android:textSize="30sp"
-        app:layout_constraintEnd_toEndOf="@+id/textview_HighHubTele"
-        app:layout_constraintTop_toTopOf="@+id/button_cargoScoredHighTeleMinus" />
-
-    <TextView
-        android:id="@+id/textview_AverageScoredTeleop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="32dp"
-        android:text="@string/AvgCargoScored"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/textview_LowHubTele"
-        android:layout_width="208dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:text="@string/TypicalCargoStoredLow"
-        android:textAlignment="center"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/button_cargoScoredHighTeleMinus"
-        app:layout_constraintTop_toBottomOf="@+id/button_cargoScoredHighTeleMinus" />
-
-    <Button
-        android:id="@+id/textButton_cargoScoredHighTeleCounter"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:background="@android:color/transparent"
-        android:text="0"
-        android:textAlignment="center"
-        android:textSize="40sp"
-        app:layout_constraintEnd_toStartOf="@+id/button_cargoScoredHighTelePlus"
-        app:layout_constraintStart_toEndOf="@+id/button_cargoScoredHighTeleMinus"
-        app:layout_constraintTop_toTopOf="@+id/button_cargoScoredHighTeleMinus" />
 
     <Button
         android:id="@+id/button_evadeDefenseYes"
@@ -276,35 +164,5 @@
         android:textAlignment="viewStart"
         app:layout_constraintStart_toStartOf="@+id/textview_teleopStrategy"
         app:layout_constraintTop_toBottomOf="@+id/textview_teleopStrategy" />
-
-    <TextView
-        android:id="@+id/textview_HighHubTele"
-        android:layout_width="208dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/TypicalCargoStoredHigh"
-        android:textAlignment="center"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/textview_AverageScoredTeleop"
-        app:layout_constraintTop_toBottomOf="@+id/textview_AverageScoredTeleop" />
-
-    <TextView
-        android:id="@+id/textview_CarryingCapacity"
-        android:layout_width="238dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:text="@string/CarryingCapacity"
-        android:textSize="30sp"
-        app:layout_constraintStart_toStartOf="@+id/button_cargoScoredLowTeleMinus"
-        app:layout_constraintTop_toBottomOf="@+id/button_cargoScoredLowTeleMinus" />
-
-    <View
-        android:id="@+id/divider5"
-        android:layout_width="5dp"
-        android:layout_height="798dp"
-        android:background="?android:attr/listDivider"
-        app:layout_constraintEnd_toStartOf="@+id/textview_sortCargo"
-        app:layout_constraintStart_toEndOf="@+id/textview_AverageScoredTeleop"
-        app:layout_constraintTop_toTopOf="parent" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Changed layouts and fixed on resume for most tabs. In AndroidManifest.xml, added a line of code to make screen scroll so as to not have keyboard cover what you are typing